### PR TITLE
ci: Further increase pyleak blocking threshold to 5.0s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           uv run install-assets install latest
       - name: Run pytest tests
-        run: uv run pytest --cov=src --cov-fail-under=77 -m "not expensive" --blocking-threshold=2.0
+        run: uv run pytest --cov=src --cov-fail-under=77 -m "not expensive" --blocking-threshold=5.0
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Further increases the pyleak blocking threshold from 2.0s to 5.0s to address intermittent CI failures.

## Problem

PR #10 increased the threshold from 0.5s to 2.0s, which improved CI reliability but still resulted in occasional failures on slower GitHub Actions runners.

## Solution

Increase `--blocking-threshold` from 2.0s to 5.0s, providing 10x the original tolerance while still catching genuine blocking issues.

## Changes

- `.github/workflows/ci.yml`: Updated pytest command from `--blocking-threshold=2.0` to `--blocking-threshold=5.0`

## Testing

- Pre-commit checks: ✅ Passed
- CI will validate this change automatically

## Impact

- Provides more headroom for slower CI runners
- Reduces false positives from pyleak blocking detection
- Still effective at catching blocking operations >5 seconds
- No changes to actual application code