### PR TITLE
docs: Update README hardware section with tested devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,23 @@ For permanent installations on Raspberry Pi and similar devices:
 
 ## 🖥️ Hardware
 
-BirdNET-Pi is designed for flexibility. It runs beautifully on a variety of single-board
-computers:
+BirdNET-Pi is designed for flexibility. It runs on a variety of single-board computers:
 
-* Raspberry Pi 4B / 400 / 3B+
-* Libre Computer "Le Potato"
-* Libre Computer "Renegade"
+**Raspberry Pi:**
+* Raspberry Pi 5
+* Raspberry Pi 4B
+* Raspberry Pi 3B/3B+
+* Raspberry Pi Zero 2W
 
-Thanks to the new modular architecture, you can even run the recording, database, and
+**Orange Pi (with DietPi/Armbian):**
+* Orange Pi Zero 2W
+* Orange Pi 5 Plus
+* Orange Pi 5 Pro
+
+**Other ARM64 Boards:**
+* Radxa ROCK 5B
+
+Thanks to the modular architecture, you can also run the recording, database, and
 analysis services on separate machines for advanced, distributed setups.
 
 ## 🙏 Attributions and Acknowledgements


### PR DESCRIPTION
## Summary
Update the hardware section to reflect currently tested and supported devices.

## Changes
**Added:**
- Raspberry Pi 5, Raspberry Pi Zero 2W
- Orange Pi Zero 2W, Orange Pi 5 Plus, Orange Pi 5 Pro
- Radxa ROCK 5B

**Removed:**
- Libre Computer "Le Potato" and "Renegade" (not in current tested list)
- Raspberry Pi 400 (not explicitly tested, though likely works)

The new list matches `get_supported_devices()` in `src/birdnetpi/cli/setup_system.py`.

## Test plan
- [x] Pre-commit checks pass
- [x] README renders correctly on GitHub