### PR TITLE
fix: Pass environment variables through su - in installer

### DIFF
--- a/tests/birdnetpi/web/routers/test_sqladmin_view_routes.py
+++ b/tests/birdnetpi/web/routers/test_sqladmin_view_routes.py
@@ -59,6 +59,7 @@ class TestSQLAdminViewRoutes:
         """Should setup_sqladmin creates and configures Admin instance."""
         app = FastAPI()
         mock_container = MagicMock(spec=Container)
+        # AsyncEngine is not awaited in this context, use MagicMock with proper spec
         mock_async_engine = MagicMock(spec=AsyncEngine)
         mock_db_service = MagicMock(spec=CoreDatabaseService, async_engine=mock_async_engine)
         mock_container.core_database.return_value = mock_db_service
@@ -88,6 +89,7 @@ class TestSQLAdminViewRoutes:
         """Should setup_sqladmin returns the Admin instance."""
         app = FastAPI()
         mock_container = MagicMock(spec=Container)
+        # AsyncEngine is not awaited in this context, use MagicMock with proper spec
         mock_async_engine = MagicMock(spec=AsyncEngine)
         mock_db_service = MagicMock(spec=CoreDatabaseService, async_engine=mock_async_engine)
         mock_container.core_database.return_value = mock_db_service


### PR DESCRIPTION
## Summary
- Fix environment variable passthrough when installer runs setup as birdnet user via `su -`
- The `su -` command resets the environment, so BIRDNETPI_* config variables were being lost
- Now explicitly passes these variables through the command string

## Test plan
- [ ] Run installer with BIRDNETPI_LATITUDE, BIRDNETPI_TIMEZONE etc. set
- [ ] Verify config values are picked up by setup script