### PR TITLE
feat: Implement region pack download with progress tracking

### DIFF
--- a/src/birdnetpi/detections/queries.py
+++ b/src/birdnetpi/detections/queries.py
@@ -2402,9 +2402,10 @@ class DetectionQueryService:
 
                 count_result = await session.execute(count_query, params)
                 count_row = count_result.fetchone()
-                total_count = count_row.total if count_row else 0  # type: ignore[attr-defined]
-                detected_count = count_row.detected if count_row else 0  # type: ignore[attr-defined]
-                undetected_count = count_row.undetected if count_row else 0  # type: ignore[attr-defined]
+                # SUM returns NULL when there are no rows, so handle None values
+                total_count = (count_row.total or 0) if count_row else 0  # type: ignore[attr-defined]
+                detected_count = (count_row.detected or 0) if count_row else 0  # type: ignore[attr-defined]
+                undetected_count = (count_row.undetected or 0) if count_row else 0  # type: ignore[attr-defined]
 
                 # Calculate offset for pagination
                 offset = (page - 1) * per_page

--- a/src/birdnetpi/releases/region_pack_service.py
+++ b/src/birdnetpi/releases/region_pack_service.py
@@ -1,0 +1,206 @@
+"""Service for downloading and installing eBird region packs.
+
+This module provides reusable functionality for downloading region packs
+that can be used by both the CLI and background daemons.
+"""
+
+import gzip
+import logging
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+from urllib.request import urlopen
+
+from birdnetpi.releases.registry_service import RegionPackInfo, RegistryService
+from birdnetpi.system.path_resolver import PathResolver
+
+logger = logging.getLogger(__name__)
+
+
+class RegionPackService:
+    """Service for downloading and managing region packs."""
+
+    def __init__(self, path_resolver: PathResolver) -> None:
+        """Initialize the region pack service.
+
+        Args:
+            path_resolver: Path resolver for determining install locations.
+        """
+        self.path_resolver = path_resolver
+        self.registry_service = RegistryService(path_resolver)
+
+    def get_install_path(self, region_id: str) -> Path:
+        """Get the installation path for a region pack.
+
+        Args:
+            region_id: The region identifier.
+
+        Returns:
+            Path where the region pack database should be installed.
+        """
+        db_dir = self.path_resolver.data_dir / "database"
+        db_dir.mkdir(parents=True, exist_ok=True)
+        return db_dir / f"{region_id}.db"
+
+    def is_installed(self, region_id: str) -> bool:
+        """Check if a region pack is already installed.
+
+        Args:
+            region_id: The region identifier.
+
+        Returns:
+            True if the pack is installed, False otherwise.
+        """
+        return self.get_install_path(region_id).exists()
+
+    def find_pack_for_coordinates(self, lat: float, lon: float) -> RegionPackInfo | None:
+        """Find the appropriate region pack for given coordinates.
+
+        Args:
+            lat: Latitude.
+            lon: Longitude.
+
+        Returns:
+            Region pack info or None if no pack covers the coordinates.
+        """
+        return self.registry_service.find_pack_for_coordinates(lat, lon)
+
+    def download_and_install(
+        self,
+        region_pack: RegionPackInfo,
+        force: bool = False,
+        progress_callback: Callable[[float, float], None] | None = None,
+    ) -> Path:
+        """Download and install a region pack.
+
+        Args:
+            region_pack: The region pack info with download URL.
+            force: If True, overwrite existing pack.
+            progress_callback: Optional callback(downloaded_mb, total_mb) for progress.
+
+        Returns:
+            Path to the installed database file.
+
+        Raises:
+            ValueError: If pack has no download URL.
+            FileExistsError: If pack exists and force is False.
+            Exception: If download or extraction fails.
+        """
+        if not region_pack.download_url:
+            raise ValueError(f"Region pack '{region_pack.region_id}' has no download URL")
+
+        return self.download_from_url(
+            region_id=region_pack.region_id,
+            download_url=region_pack.download_url,
+            size_mb=region_pack.total_size_mb,
+            force=force,
+            progress_callback=progress_callback,
+        )
+
+    def download_from_url(
+        self,
+        region_id: str,
+        download_url: str,
+        size_mb: float = 0,
+        force: bool = False,
+        progress_callback: Callable[[float, float], None] | None = None,
+    ) -> Path:
+        """Download and install a region pack from a direct URL.
+
+        This method is used by daemons that receive download requests with
+        minimal info (just region_id and URL) without the full RegionPackInfo.
+
+        Args:
+            region_id: The region identifier.
+            download_url: Direct download URL for the .db.gz file.
+            size_mb: Expected size in MB (for logging, 0 if unknown).
+            force: If True, overwrite existing pack.
+            progress_callback: Optional callback(downloaded_mb, total_mb) for progress.
+
+        Returns:
+            Path to the installed database file.
+
+        Raises:
+            FileExistsError: If pack exists and force is False.
+            Exception: If download or extraction fails.
+        """
+        output_path = self.get_install_path(region_id)
+
+        if output_path.exists() and not force:
+            raise FileExistsError(f"Region pack '{region_id}' already installed at {output_path}")
+
+        if size_mb > 0:
+            logger.info("Downloading region pack '%s' (%.1f MB)", region_id, size_mb)
+        else:
+            logger.info("Downloading region pack '%s'", region_id)
+
+        try:
+            self._download_and_extract(download_url, output_path, progress_callback)
+
+            logger.info(
+                "Region pack '%s' installed successfully at %s",
+                region_id,
+                output_path,
+            )
+            return output_path
+
+        except Exception:
+            # Clean up partial download on failure
+            if output_path.exists():
+                output_path.unlink()
+            temp_gz = output_path.with_suffix(".db.gz")
+            if temp_gz.exists():
+                temp_gz.unlink()
+            raise
+
+    def _download_and_extract(
+        self,
+        download_url: str,
+        output_path: Path,
+        progress_callback: Callable[[float, float], None] | None = None,
+    ) -> None:
+        """Download and extract a .db.gz file.
+
+        Args:
+            download_url: GitHub release asset download URL.
+            output_path: Path where the .db file should be saved.
+            progress_callback: Optional callback(downloaded_mb, total_mb) for progress.
+        """
+        logger.debug("Downloading from: %s", download_url)
+
+        # Download the .db.gz file
+        with urlopen(download_url, timeout=300) as response:  # nosemgrep
+            total_size = int(response.headers.get("Content-Length", 0))
+            total_mb = total_size / 1024 / 1024
+            chunk_size = 8192
+            downloaded = 0
+
+            # Create a temporary file for the compressed download
+            temp_gz = output_path.with_suffix(".db.gz")
+
+            with open(temp_gz, "wb") as f:
+                while True:
+                    chunk = response.read(chunk_size)
+                    if not chunk:
+                        break
+
+                    f.write(chunk)
+                    downloaded += len(chunk)
+
+                    # Report progress
+                    if progress_callback and total_size > 0:
+                        downloaded_mb = downloaded / 1024 / 1024
+                        progress_callback(downloaded_mb, total_mb)
+
+        logger.debug("Download complete, extracting...")
+
+        # Extract the .db.gz file to .db
+        with gzip.open(temp_gz, "rb") as f_in:
+            with open(output_path, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+        # Remove the temporary .gz file
+        temp_gz.unlink()
+
+        file_size_mb = output_path.stat().st_size / 1024 / 1024
+        logger.debug("Extraction complete (%.1f MB)", file_size_mb)

--- a/src/birdnetpi/releases/region_pack_status.py
+++ b/src/birdnetpi/releases/region_pack_status.py
@@ -150,20 +150,29 @@ class RegionPackStatusService:
             return []
 
         # Find all .db files that match region pack naming pattern
-        # Pattern: name-YYYY.MM.db or name-YYYY-MM-DD.db
+        # Pattern: region-###.db (e.g., na-east-054.db) or name-YYYY.MM.db
         packs = []
         for db_file in db_dir.glob("*.db"):
-            # Skip main databases
+            # Skip main databases and WAL/SHM files
             if db_file.name in [
                 "birdnetpi.db",
                 "ioc_reference.db",
                 "avibase_database.db",
                 "patlevin_database.db",
+                "wikidata_reference.db",
             ]:
                 continue
 
-            # Check if it matches region pack pattern
-            if re.match(r"^.+-\d{4}[.-]\d{2}", db_file.stem):
+            # Skip SQLite WAL/SHM files
+            if db_file.suffix in [".db-wal", ".db-shm"]:
+                continue
+
+            # Check if it matches region pack patterns:
+            # - New format: region-### (e.g., na-east-054)
+            # - Old format: region-YYYY.MM or region-YYYY-MM-DD
+            if re.match(r"^[a-z]+-[a-z]+-\d{3}$", db_file.stem) or re.match(
+                r"^.+-\d{4}[.-]\d{2}", db_file.stem
+            ):
                 packs.append(db_file)
 
         return sorted(packs)

--- a/src/birdnetpi/web/models/update.py
+++ b/src/birdnetpi/web/models/update.py
@@ -69,3 +69,21 @@ class GitBranchListResponse(BaseModel):
 
     tags: list[str]
     branches: list[str]
+
+
+class RegionPackDownloadStatusResponse(BaseModel):
+    """Response model for region pack download status.
+
+    Status values:
+    - idle: No download in progress
+    - downloading: Download is in progress
+    - complete: Download finished successfully
+    - error: Download failed
+    """
+
+    status: str  # idle, downloading, complete, error
+    region_id: str | None = None
+    progress: int | None = None  # 0-100 percentage
+    downloaded_mb: float | None = None
+    total_mb: float | None = None
+    error: str | None = None

--- a/src/birdnetpi/web/routers/i18n_api_routes.py
+++ b/src/birdnetpi/web/routers/i18n_api_routes.py
@@ -109,6 +109,13 @@ async def get_translations_json(
         "failed-to-apply-update": translation.gettext("Failed to apply update"),
         "failed-to-cancel-update": translation.gettext("Failed to cancel update"),
         "failed-to-save-git-config": translation.gettext("Failed to save git configuration"),
+        # Region pack messages
+        "downloading": translation.gettext("Downloading"),
+        "download-queued": translation.gettext("Download queued"),
+        "download-region-pack": translation.gettext("Download region pack"),
+        "download-complete": translation.gettext("Download complete"),
+        "region-pack-installed": translation.gettext("Region pack installed successfully"),
+        "failed-to-download-region-pack": translation.gettext("Failed to download region pack"),
     }
 
     # Use the language we determined earlier

--- a/src/birdnetpi/web/routers/update_api_routes.py
+++ b/src/birdnetpi/web/routers/update_api_routes.py
@@ -23,6 +23,7 @@ from birdnetpi.web.models.update import (
     GitRemoteListResponse,
     GitRemoteModel,
     GitRemoteRequest,
+    RegionPackDownloadStatusResponse,
     UpdateActionResponse,
     UpdateApplyRequest,
     UpdateCheckRequest,
@@ -605,3 +606,22 @@ async def download_region_pack(
     except Exception as e:
         logger.error("Failed to download region pack: %s", e)
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/region-pack/download-status", response_model=RegionPackDownloadStatusResponse)
+@require_admin
+@inject
+async def get_region_pack_download_status(
+    request: Request,
+    cache: Annotated[Cache, Depends(Provide[Container.cache_service])],
+) -> RegionPackDownloadStatusResponse:
+    """Get region pack download progress.
+
+    Returns:
+        Download status including progress percentage.
+        Status can be: idle, downloading, complete, or error.
+    """
+    status = cache.get("region_pack:download_status")
+    if not status:
+        return RegionPackDownloadStatusResponse(status="idle")
+    return RegionPackDownloadStatusResponse(**status)

--- a/src/birdnetpi/web/static/js/update.js
+++ b/src/birdnetpi/web/static/js/update.js
@@ -573,9 +573,80 @@ const gitRemoteManager = {
   },
 };
 
+// Region Pack Management
+const regionPackManager = {
+  downloadBtn: null,
+
+  init() {
+    this.downloadBtn = document.getElementById("download-region-pack-btn");
+
+    if (this.downloadBtn) {
+      this.downloadBtn.addEventListener("click", () =>
+        this.downloadRegionPack(),
+      );
+    }
+  },
+
+  async downloadRegionPack() {
+    try {
+      this.downloadBtn.disabled = true;
+      this.downloadBtn.textContent = _("downloading");
+
+      const response = await fetch("/api/update/region-pack/download", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const data = await response.json();
+
+      if (response.ok && data.success) {
+        this.downloadBtn.textContent = _("download-queued");
+        this.showNotification(data.message, "success");
+        // Reload page after a short delay to show updated status
+        setTimeout(() => {
+          window.location.reload();
+        }, 2000);
+      } else {
+        this.downloadBtn.textContent = _("download-region-pack");
+        this.downloadBtn.disabled = false;
+        this.showNotification(
+          data.error || _("failed-to-download-region-pack"),
+          "error",
+        );
+      }
+    } catch (error) {
+      console.error("Failed to download region pack:", error);
+      this.downloadBtn.disabled = false;
+      this.downloadBtn.textContent = _("download-region-pack");
+      this.showNotification(
+        _("failed-to-download-region-pack") + ": " + error.message,
+        "error",
+      );
+    }
+  },
+
+  showNotification(message, type) {
+    const notification = document.createElement("div");
+    notification.className = "notification notification-" + type;
+    notification.textContent = message;
+    notification.style.cssText =
+      "position: fixed; top: 20px; right: 20px; padding: 1rem 1.5rem; " +
+      "border-radius: 8px; background: " +
+      (type === "success" ? "#10b981" : "#ef4444") +
+      "; " +
+      "color: white; z-index: 1000; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);";
+    document.body.appendChild(notification);
+
+    setTimeout(() => {
+      notification.remove();
+    }, 5000);
+  },
+};
+
 // Initialize on page load
 document.addEventListener("DOMContentLoaded", () => {
   updateManager.init();
   gitConfig.init();
   gitRemoteManager.init();
+  regionPackManager.init();
 });

--- a/tests/birdnetpi/releases/test_region_pack_service.py
+++ b/tests/birdnetpi/releases/test_region_pack_service.py
@@ -1,0 +1,294 @@
+"""Tests for the RegionPackService."""
+
+import gzip
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from birdnetpi.releases.region_pack_service import RegionPackService
+from birdnetpi.releases.registry_service import BoundingBox, RegionPackInfo
+
+
+class MockHTTPResponse:
+    """Mock HTTP response for testing urlopen calls."""
+
+    def __init__(self, data: bytes, content_length: int | None = None):
+        """Initialize mock response."""
+        self._data = data
+        self._read_called = False
+        self.headers = {"Content-Length": str(content_length or len(data))}
+
+    def __enter__(self) -> "MockHTTPResponse":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self, size: int = -1) -> bytes:
+        """Return data on first call, empty bytes on subsequent calls."""
+        if self._read_called:
+            return b""
+        self._read_called = True
+        return self._data
+
+
+class MockHTTPResponseError:
+    """Mock HTTP response that raises an error on read."""
+
+    def __init__(self, error: Exception):
+        """Initialize mock response."""
+        self._error = error
+        self.headers = {"Content-Length": "1000"}
+
+    def __enter__(self) -> "MockHTTPResponseError":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self, size: int = -1) -> bytes:
+        """Raise an error."""
+        raise self._error
+
+
+def make_region_pack_info(
+    region_id: str = "test-region-001",
+    download_url: str | None = "https://example.com/pack.db.gz",
+    total_size_mb: float = 10.0,
+) -> RegionPackInfo:
+    """Create a valid RegionPackInfo for testing."""
+    return RegionPackInfo(
+        region_id=region_id,
+        release_name=f"{region_id}-v1",
+        h3_cells=["8615f2", "8615f3"],
+        pack_count=2,
+        total_size_mb=total_size_mb,
+        resolution=6,
+        center={"lat": 45.0, "lon": -75.0},
+        bbox=BoundingBox(min_lat=44.0, max_lat=46.0, min_lon=-76.0, max_lon=-74.0),
+        download_url=download_url,
+    )
+
+
+class TestRegionPackService:
+    """Test suite for RegionPackService."""
+
+    def test_init(self, path_resolver):
+        """Should initialize with path resolver and registry service."""
+        service = RegionPackService(path_resolver)
+
+        assert service.path_resolver == path_resolver
+        assert service.registry_service is not None
+
+    def test_get_install_path(self, path_resolver):
+        """Should return correct install path for a region."""
+        service = RegionPackService(path_resolver)
+        expected_dir = path_resolver.data_dir / "database"
+
+        result = service.get_install_path("na-east-054")
+
+        assert result == expected_dir / "na-east-054.db"
+
+    def test_get_install_path_creates_directory(self, path_resolver):
+        """Should create database directory if it doesn't exist."""
+        service = RegionPackService(path_resolver)
+        db_dir = path_resolver.data_dir / "database"
+
+        # Ensure directory doesn't exist first
+        if db_dir.exists():
+            import shutil
+
+            shutil.rmtree(db_dir)
+
+        service.get_install_path("na-east-054")
+
+        assert db_dir.exists()
+
+    def test_is_installed_returns_false_when_not_installed(self, path_resolver):
+        """Should return False when pack is not installed."""
+        service = RegionPackService(path_resolver)
+
+        result = service.is_installed("nonexistent-region-123")
+
+        assert result is False
+
+    def test_is_installed_returns_true_when_installed(self, path_resolver):
+        """Should return True when pack is installed."""
+        service = RegionPackService(path_resolver)
+
+        # Create the database file
+        install_path = service.get_install_path("test-region-001")
+        install_path.parent.mkdir(parents=True, exist_ok=True)
+        install_path.touch()
+
+        result = service.is_installed("test-region-001")
+
+        assert result is True
+
+    def test_find_pack_for_coordinates_delegates_to_registry(self, path_resolver):
+        """Should delegate coordinate lookup to registry service."""
+        service = RegionPackService(path_resolver)
+        mock_pack = MagicMock(spec=RegionPackInfo)
+
+        with patch.object(
+            service.registry_service,
+            "find_pack_for_coordinates",
+            return_value=mock_pack,
+        ) as mock_find:
+            result = service.find_pack_for_coordinates(45.0, -75.0)
+
+            mock_find.assert_called_once_with(45.0, -75.0)
+            assert result == mock_pack
+
+    def test_download_and_install_raises_without_url(self, path_resolver):
+        """Should raise ValueError when pack has no download URL."""
+        service = RegionPackService(path_resolver)
+        pack = make_region_pack_info(region_id="test-001", download_url=None)
+
+        with pytest.raises(ValueError, match="no download URL"):
+            service.download_and_install(pack)
+
+    def test_download_and_install_raises_if_exists_without_force(self, path_resolver):
+        """Should raise FileExistsError when pack exists and force is False."""
+        service = RegionPackService(path_resolver)
+
+        # Create existing file
+        install_path = service.get_install_path("existing-pack-001")
+        install_path.parent.mkdir(parents=True, exist_ok=True)
+        install_path.touch()
+
+        pack = make_region_pack_info(region_id="existing-pack-001", total_size_mb=10.0)
+
+        with pytest.raises(FileExistsError, match="already installed"):
+            service.download_and_install(pack)
+
+    def test_download_from_url_success(self, path_resolver, tmp_path):
+        """Should download and extract gzipped database file."""
+        service = RegionPackService(path_resolver)
+
+        # Create a test gzipped database
+        test_content = b"SQLite format 3\x00" + b"\x00" * 100
+        compressed = gzip.compress(test_content)
+
+        # Use MockHTTPResponse instead of MagicMock
+        mock_response = MockHTTPResponse(compressed)
+
+        with patch(
+            "birdnetpi.releases.region_pack_service.urlopen",
+            return_value=mock_response,
+        ):
+            result = service.download_from_url(
+                region_id="download-test-001",
+                download_url="https://example.com/pack.db.gz",
+                size_mb=1.0,
+            )
+
+        assert result.exists()
+        assert result.name == "download-test-001.db"
+        # Check content was extracted
+        assert result.read_bytes() == test_content
+
+    def test_download_from_url_with_progress_callback(self, path_resolver):
+        """Should call progress callback during download."""
+        service = RegionPackService(path_resolver)
+
+        # Create test data
+        test_content = b"test database content"
+        compressed = gzip.compress(test_content)
+
+        # Track progress calls
+        progress_calls: list[tuple[float, float]] = []
+
+        def track_progress(downloaded: float, total: float) -> None:
+            progress_calls.append((downloaded, total))
+
+        # Use MockHTTPResponse instead of MagicMock
+        mock_response = MockHTTPResponse(compressed)
+
+        with patch(
+            "birdnetpi.releases.region_pack_service.urlopen",
+            return_value=mock_response,
+        ):
+            service.download_from_url(
+                region_id="progress-test-001",
+                download_url="https://example.com/pack.db.gz",
+                progress_callback=track_progress,
+            )
+
+        # Should have been called at least once
+        assert len(progress_calls) > 0
+
+    def test_download_from_url_cleans_up_on_failure(self, path_resolver):
+        """Should clean up partial files on download failure."""
+        service = RegionPackService(path_resolver)
+
+        # Use MockHTTPResponseError to raise an error on read
+        mock_response = MockHTTPResponseError(Exception("Network error"))
+
+        with (
+            patch(
+                "birdnetpi.releases.region_pack_service.urlopen",
+                return_value=mock_response,
+            ),
+            pytest.raises(Exception, match="Network error"),
+        ):
+            service.download_from_url(
+                region_id="cleanup-test-001",
+                download_url="https://example.com/pack.db.gz",
+            )
+
+        # Verify no partial files remain
+        install_path = service.get_install_path("cleanup-test-001")
+        assert not install_path.exists()
+        assert not install_path.with_suffix(".db.gz").exists()
+
+    def test_download_and_install_delegates_to_download_from_url(self, path_resolver):
+        """Should delegate to download_from_url with pack info."""
+        service = RegionPackService(path_resolver)
+        pack = make_region_pack_info(region_id="delegate-test-001", total_size_mb=15.5)
+
+        with patch.object(
+            service,
+            "download_from_url",
+            return_value=Path("/fake/path.db"),
+        ) as mock_download:
+            result = service.download_and_install(pack, force=True)
+
+            mock_download.assert_called_once_with(
+                region_id="delegate-test-001",
+                download_url="https://example.com/pack.db.gz",
+                size_mb=15.5,
+                force=True,
+                progress_callback=None,
+            )
+            assert result == Path("/fake/path.db")
+
+    def test_download_from_url_force_overwrites_existing(self, path_resolver):
+        """Should overwrite existing file when force is True."""
+        service = RegionPackService(path_resolver)
+
+        # Create existing file
+        install_path = service.get_install_path("force-test-001")
+        install_path.parent.mkdir(parents=True, exist_ok=True)
+        install_path.write_text("old content")
+
+        # Create test data
+        new_content = b"new database content"
+        compressed = gzip.compress(new_content)
+
+        # Use MockHTTPResponse instead of MagicMock
+        mock_response = MockHTTPResponse(compressed)
+
+        with patch(
+            "birdnetpi.releases.region_pack_service.urlopen",
+            return_value=mock_response,
+        ):
+            result = service.download_from_url(
+                region_id="force-test-001",
+                download_url="https://example.com/pack.db.gz",
+                force=True,
+            )
+
+        assert result.exists()
+        assert result.read_bytes() == new_content


### PR DESCRIPTION
## Summary

- Add JavaScript handler for region pack download button
- Implement background download processing via update daemon using Redis queue
- Add download progress polling with real-time UI updates
- Fix region pack detection to recognize new `na-east-###` naming pattern

## Changes

### New Files
- `src/birdnetpi/releases/region_pack_service.py` - Reusable download logic for CLI and daemon

### Modified Files
- `src/birdnetpi/daemons/update_daemon.py` - Process region pack download requests from Redis
- `src/birdnetpi/releases/region_pack_status.py` - Fix pack detection regex for new naming format
- `src/birdnetpi/web/models/update.py` - Add `RegionPackDownloadStatusResponse` Pydantic model
- `src/birdnetpi/web/routers/update_api_routes.py` - Add `/region-pack/download-status` endpoint
- `src/birdnetpi/web/routers/i18n_api_routes.py` - Add translation keys for download status
- `src/birdnetpi/web/static/js/update.js` - Add progress polling and UI updates

## How It Works

1. User clicks "Download region pack" button
2. FastAPI queues download request in Redis
3. Update daemon picks up request and downloads pack in background
4. Progress is stored in Redis (`region_pack:download_status`)
5. JavaScript polls for progress and updates button text (e.g., "Downloading 45% (10.5/24.3 MB)")
6. On completion, page reloads and banner disappears

## Test Plan

- [ ] Click download button on update page
- [ ] Verify button shows download progress percentage
- [ ] Verify region pack banner disappears after installation
- [ ] Verify pack appears in database directory