### PR TITLE
fix: Timezone display, region pack naming, eBird filtering, and service restart

### DIFF
--- a/src/birdnetpi/releases/region_pack_status.py
+++ b/src/birdnetpi/releases/region_pack_status.py
@@ -64,9 +64,9 @@ class RegionPackStatusService:
             try:
                 region_info = self.registry_service.find_pack_for_coordinates(lat, lon)
                 if region_info:
-                    recommended_pack = region_info.region_id
+                    recommended_pack = region_info.release_name
                     # Check if we have the correct pack locally
-                    recommended_file = f"{region_info.region_id}.db"
+                    recommended_file = f"{region_info.release_name}.db"
                     correct_pack_installed = any(
                         p.name == recommended_file for p in available_packs
                     )

--- a/src/birdnetpi/web/models/detections.py
+++ b/src/birdnetpi/web/models/detections.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 # ==================== Request Models ====================
 
@@ -80,6 +80,14 @@ class DetectionResponse(BaseModel):
     is_first_in_period: bool | None = None
     first_ever_detection: datetime | None = None
     first_period_detection: datetime | None = None
+
+    @field_serializer("timestamp", "first_ever_detection", "first_period_detection")
+    @classmethod
+    def serialize_datetime_utc(cls, v: datetime | None) -> str | None:
+        """Serialize datetime with Z suffix to indicate UTC."""
+        if v is None:
+            return None
+        return v.isoformat() + "Z"
 
 
 class SpeciesInfo(BaseModel):
@@ -235,6 +243,14 @@ class DetectionDetailResponse(BaseModel):
     family: str | None = None
     genus: str | None = None
     order_name: str | None = None
+
+    @field_serializer("timestamp")
+    @classmethod
+    def serialize_datetime_utc(cls, v: datetime | None) -> str | None:
+        """Serialize datetime with Z suffix to indicate UTC."""
+        if v is None:
+            return None
+        return v.isoformat() + "Z"
 
 
 class SpeciesSummaryResponse(BaseModel):

--- a/src/birdnetpi/web/models/detections.py
+++ b/src/birdnetpi/web/models/detections.py
@@ -81,13 +81,23 @@ class DetectionResponse(BaseModel):
     first_ever_detection: datetime | None = None
     first_period_detection: datetime | None = None
 
-    @field_serializer("timestamp", "first_ever_detection", "first_period_detection")
+    @field_serializer(
+        "timestamp", "first_ever_detection", "first_period_detection", when_used="json"
+    )
     @classmethod
     def serialize_datetime_utc(cls, v: datetime | None) -> str | None:
-        """Serialize datetime with Z suffix to indicate UTC."""
+        """Serialize datetime with Z suffix to indicate UTC (JSON mode only).
+
+        Replaces +00:00 suffix with Z for cleaner ISO 8601 format.
+        Only applies when serializing to JSON, not when using model_dump().
+        """
         if v is None:
             return None
-        return v.isoformat() + "Z"
+        iso_str = v.isoformat()
+        # Replace +00:00 with Z for standard UTC format
+        if iso_str.endswith("+00:00"):
+            return iso_str[:-6] + "Z"
+        return iso_str + "Z"
 
 
 class SpeciesInfo(BaseModel):
@@ -244,13 +254,21 @@ class DetectionDetailResponse(BaseModel):
     genus: str | None = None
     order_name: str | None = None
 
-    @field_serializer("timestamp")
+    @field_serializer("timestamp", when_used="json")
     @classmethod
     def serialize_datetime_utc(cls, v: datetime | None) -> str | None:
-        """Serialize datetime with Z suffix to indicate UTC."""
+        """Serialize datetime with Z suffix to indicate UTC (JSON mode only).
+
+        Replaces +00:00 suffix with Z for cleaner ISO 8601 format.
+        Only applies when serializing to JSON, not when using model_dump().
+        """
         if v is None:
             return None
-        return v.isoformat() + "Z"
+        iso_str = v.isoformat()
+        # Replace +00:00 with Z for standard UTC format
+        if iso_str.endswith("+00:00"):
+            return iso_str[:-6] + "Z"
+        return iso_str + "Z"
 
 
 class SpeciesSummaryResponse(BaseModel):

--- a/src/birdnetpi/web/models/update.py
+++ b/src/birdnetpi/web/models/update.py
@@ -82,7 +82,7 @@ class RegionPackDownloadStatusResponse(BaseModel):
     """
 
     status: str  # idle, downloading, complete, error
-    region_id: str | None = None
+    release_name: str | None = None
     progress: int | None = None  # 0-100 percentage
     downloaded_mb: float | None = None
     total_mb: float | None = None

--- a/src/birdnetpi/web/routers/update_api_routes.py
+++ b/src/birdnetpi/web/routers/update_api_routes.py
@@ -588,7 +588,7 @@ async def download_region_pack(
         cache.set(
             "region_pack:download_request",
             {
-                "region_id": region_pack.region_id,
+                "release_name": region_pack.release_name,
                 "download_url": region_pack.download_url,
                 "size_mb": region_pack.total_size_mb,
             },

--- a/tests/birdnetpi/releases/test_region_pack_service.py
+++ b/tests/birdnetpi/releases/test_region_pack_service.py
@@ -153,12 +153,12 @@ class TestRegionPackService:
         """Should raise FileExistsError when pack exists and force is False."""
         service = RegionPackService(path_resolver)
 
-        # Create existing file
-        install_path = service.get_install_path("existing-pack-001")
+        pack = make_region_pack_info(region_id="existing-pack-001", total_size_mb=10.0)
+
+        # Create existing file using the release_name (which is used for install path)
+        install_path = service.get_install_path(pack.release_name)
         install_path.parent.mkdir(parents=True, exist_ok=True)
         install_path.touch()
-
-        pack = make_region_pack_info(region_id="existing-pack-001", total_size_mb=10.0)
 
         with pytest.raises(FileExistsError, match="already installed"):
             service.download_and_install(pack)
@@ -179,7 +179,7 @@ class TestRegionPackService:
             return_value=mock_response,
         ):
             result = service.download_from_url(
-                region_id="download-test-001",
+                release_name="download-test-001",
                 download_url="https://example.com/pack.db.gz",
                 size_mb=1.0,
             )
@@ -211,7 +211,7 @@ class TestRegionPackService:
             return_value=mock_response,
         ):
             service.download_from_url(
-                region_id="progress-test-001",
+                release_name="progress-test-001",
                 download_url="https://example.com/pack.db.gz",
                 progress_callback=track_progress,
             )
@@ -234,7 +234,7 @@ class TestRegionPackService:
             pytest.raises(Exception, match="Network error"),
         ):
             service.download_from_url(
-                region_id="cleanup-test-001",
+                release_name="cleanup-test-001",
                 download_url="https://example.com/pack.db.gz",
             )
 
@@ -256,7 +256,7 @@ class TestRegionPackService:
             result = service.download_and_install(pack, force=True)
 
             mock_download.assert_called_once_with(
-                region_id="delegate-test-001",
+                release_name="delegate-test-001-v1",
                 download_url="https://example.com/pack.db.gz",
                 size_mb=15.5,
                 force=True,
@@ -285,7 +285,7 @@ class TestRegionPackService:
             return_value=mock_response,
         ):
             result = service.download_from_url(
-                region_id="force-test-001",
+                release_name="force-test-001",
                 download_url="https://example.com/pack.db.gz",
                 force=True,
             )


### PR DESCRIPTION
## Summary

- **Timezone display**: Convert timestamps to user's configured timezone for display in dashboard and API responses
- **Region pack naming**: Use `release_name` (e.g., `na-east-054-2026.02.db`) instead of `region_id` for file naming
- **eBird filtering**: Treat unknown species as "absent" to block species not in regional database
- **Service restart**: Use detached process for supervisord restart so FastAPI can restart itself from UI
- **API timestamps**: Add Z suffix to datetime responses to indicate UTC for JavaScript clients

## Test plan

- [x] Verify dashboard shows times in local timezone (America/Toronto)
- [x] Verify eBird filtering blocks African/European species at Toronto location
- [x] Verify Ontario species are detected correctly
- [x] Verify FastAPI restart works from UI
- [x] All pre-commit checks pass
- [x] Presentation manager tests pass (30/30)