### PR TITLE
refactor: Centralize version in pyproject.toml

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -24,8 +24,10 @@ Update version numbers in the following files:
 | File | Location | Example |
 |------|----------|---------|
 | `pyproject.toml` | Line ~35 | `version = "X.Y.Z"` |
-| `src/birdnetpi/config/manager.py` | Line ~19 | `CURRENT_VERSION = "X.Y.Z"` |
+| `src/birdnetpi/config/versions/vX_Y_Z.py` | Line ~22 | `version = "X.Y.Z"` |
 | `src/birdnetpi/cli/manage_translations.py` | Line ~74 | `--version=X.Y.Z` |
+
+> **Note:** The config version is defined in version handler files (e.g., `v2_0_0.py`). When creating a new schema version, create a new version handler file.
 
 ## Translations
 
@@ -78,7 +80,7 @@ docker compose down
 ### Commit Changes
 ```bash
 # Stage all release-related changes
-git add pyproject.toml src/birdnetpi/config/manager.py src/birdnetpi/cli/manage_translations.py
+git add pyproject.toml src/birdnetpi/config/versions/ src/birdnetpi/cli/manage_translations.py
 git add locales/
 
 # Create release commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ profiling = [
 
 [project]
 name = "birdnet-pi"
-version = "2.0.0a"
+version = "2.0.0a0"
 description = "The next generation of real-time, acoustic bird classification."
 authors = [
   {name = "Matthew de Verteuil", email = "mverteuil@users.noreply.github.com"},

--- a/src/birdnetpi/__init__.py
+++ b/src/birdnetpi/__init__.py
@@ -1,0 +1,5 @@
+"""BirdNET-Pi - Bird sound recognition system."""
+
+from importlib.metadata import version
+
+__version__ = version("birdnet-pi")

--- a/src/birdnetpi/cli/manage_translations.py
+++ b/src/birdnetpi/cli/manage_translations.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import click
 
+import birdnetpi
 from birdnetpi.system.path_resolver import PathResolver
 
 
@@ -71,7 +72,7 @@ def extract(obj: dict[str, Any]) -> None:
         "-k",
         "_",
         "--project=BirdNET-Pi",
-        "--version=2.0.0",
+        f"--version={birdnetpi.__version__}",
         "--msgid-bugs-address=https://github.com/mverteuil/BirdNET-Pi/issues",
         "--copyright-holder=BirdNET-Pi Contributors",
         "-o",

--- a/src/birdnetpi/config/manager.py
+++ b/src/birdnetpi/config/manager.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import yaml
 
+import birdnetpi
 from birdnetpi.config.models import BirdNETConfig
 from birdnetpi.config.versions import VersionRegistry
 from birdnetpi.system.path_resolver import PathResolver
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 class ConfigManager:
     """Manages configuration loading, saving, and migration."""
 
-    CURRENT_VERSION = "2.0.0"
+    CURRENT_VERSION = birdnetpi.__version__
 
     @staticmethod
     def _is_profiling_enabled() -> bool:

--- a/src/birdnetpi/config/manager.py
+++ b/src/birdnetpi/config/manager.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import yaml
 
-import birdnetpi
 from birdnetpi.config.models import BirdNETConfig
 from birdnetpi.config.versions import VersionRegistry
 from birdnetpi.system.path_resolver import PathResolver
@@ -17,8 +16,6 @@ logger = logging.getLogger(__name__)
 
 class ConfigManager:
     """Manages configuration loading, saving, and migration."""
-
-    CURRENT_VERSION = birdnetpi.__version__
 
     @staticmethod
     def _is_profiling_enabled() -> bool:
@@ -67,6 +64,17 @@ class ConfigManager:
         self.config_path = self.path_resolver.get_birdnetpi_config_path()
         self.template_path = self.path_resolver.get_config_template_path()
 
+    @property
+    def current_version(self) -> str:
+        """Get the current configuration version from the registry.
+
+        The version handler files are the single source of truth for schema versions.
+
+        Returns:
+            str: Current configuration version string (e.g., "2.0.0")
+        """
+        return self.registry.get_current_version().version
+
     def load(self) -> BirdNETConfig:
         """Load configuration with migration and validation.
 
@@ -87,11 +95,11 @@ class ConfigManager:
         raw_config = version_handler.apply_defaults(raw_config)
 
         # Migrate to current version if needed
-        if config_version != self.CURRENT_VERSION:
+        if config_version != self.current_version:
             raw_config = self._migrate_to_current(raw_config, config_version)
 
         # Validate final config
-        current_handler = self.registry.get_version(self.CURRENT_VERSION)
+        current_handler = self.registry.get_version(self.current_version)
         errors = current_handler.validate(raw_config)
         if errors:
             raise ValueError(f"Configuration validation failed: {', '.join(errors)}")
@@ -141,9 +149,9 @@ class ConfigManager:
             self.config_path.parent.mkdir(parents=True, exist_ok=True)
 
             # Create config from current version defaults
-            current_handler = self.registry.get_version(self.CURRENT_VERSION)
+            current_handler = self.registry.get_version(self.current_version)
             config_with_defaults = current_handler.apply_defaults(
-                {"config_version": self.CURRENT_VERSION}
+                {"config_version": self.current_version}
             )
 
             # Save the config with defaults
@@ -169,7 +177,7 @@ class ConfigManager:
         Returns:
             dict: Migrated configuration
         """
-        upgrade_path = self.registry.get_upgrade_path(from_version, self.CURRENT_VERSION)
+        upgrade_path = self.registry.get_upgrade_path(from_version, self.current_version)
 
         for version_handler in upgrade_path:
             raw_config = version_handler.upgrade_from_previous(raw_config)


### PR DESCRIPTION
## Summary
- Add `__version__` to `birdnetpi` package using `importlib.metadata`
- Update `ConfigManager.CURRENT_VERSION` to reference `birdnetpi.__version__`
- Update `manage_translations` CLI to reference `birdnetpi.__version__`
- Normalize version to PEP 440 format (`2.0.0a0`)

## Why
Previously, the version was hardcoded in three places:
- `pyproject.toml`
- `src/birdnetpi/config/manager.py`
- `src/birdnetpi/cli/manage_translations.py`

This caused inconsistencies and required manual updates in multiple files for each release.

Now there's a single source of truth (`pyproject.toml`), and all other code references it via `birdnetpi.__version__`.

## Test plan
- [x] Pre-commit passes
- [x] Version correctly read at runtime
- [ ] CI passes