### PR TITLE
fix: Lowercase Docker image tags in release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -40,6 +40,11 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version: ${VERSION}"
 
+          # Docker tags must be lowercase; github.repository preserves case
+          IMAGE_LC="${GITHUB_REPOSITORY,,}"
+          echo "image_name=${IMAGE_LC}" >> "$GITHUB_OUTPUT"
+          echo "Image: ${IMAGE_LC}"
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -78,8 +83,8 @@ jobs:
           target: init
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-init
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-init
+            ${{ env.REGISTRY }}/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.version }}-init
+            ${{ env.REGISTRY }}/${{ steps.version.outputs.image_name }}:latest-init
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
@@ -99,13 +104,13 @@ jobs:
             echo ""
             echo "### Init Image"
             echo '```'
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-init"
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-init"
+            echo "${{ env.REGISTRY }}/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.version }}-init"
+            echo "${{ env.REGISTRY }}/${{ steps.version.outputs.image_name }}:latest-init"
             echo '```'
             echo ""
             echo "### Pull Commands"
             echo '```bash'
-            echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
-            echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-init"
+            echo "docker pull ${{ env.REGISTRY }}/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.version }}"
+            echo "docker pull ${{ env.REGISTRY }}/${{ steps.version.outputs.image_name }}:${{ steps.version.outputs.version }}-init"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Docker image release failed because `github.repository` preserves case (`mverteuil/BirdNET-Pi`) but Docker tags require lowercase
- The `docker/metadata-action` auto-lowercases for the runtime image, but init image tags were constructed manually using `${{ env.IMAGE_NAME }}`
- Added lowercase conversion in the version extraction step and updated all manual tag references

## Context
- Failed run: https://github.com/mverteuil/BirdNET-Pi/actions/runs/22327307107
- Error: `invalid tag "ghcr.io/mverteuil/BirdNET-Pi:2.0.0a0-init": repository name must be lowercase`

## Post-merge
After merging, move the `v2.0.0a0` tag to the new HEAD to re-trigger the Docker Release workflow.