### PR TITLE
fix: Bump semgrep to v1.137.0 to fix CI pkg_resources error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     hooks:
     -   id: actionlint
 -   repo: https://github.com/pappasam/toml-sort
-    rev: v0.24.3
+    rev: v0.24.4
     hooks:
     -   id: toml-sort-fix
 -   repo: https://github.com/RobertCraigie/pyright-python
@@ -59,7 +59,7 @@ repos:
     hooks:
     -   id: pyright
 -   repo: https://github.com/semgrep/semgrep
-    rev: 'v1.136.0'
+    rev: 'v1.137.0'
     hooks:
     -   id: semgrep
         args: [
@@ -69,7 +69,6 @@ repos:
           '--error'
         ]
         files: '^(src/birdnetpi|tests)/.*\.py$'
-        language_version: python3.11
         additional_dependencies: []
         verbose: false
 -   repo: https://github.com/boidolr/ast-grep-pre-commit


### PR DESCRIPTION
## Summary
- Bumps semgrep from v1.136.0 to v1.137.0 to fix `ModuleNotFoundError: No module named 'pkg_resources'` in CI
- Removes `language_version: python3.11` pin so semgrep uses the available Python interpreter
- Fix confirmed upstream: semgrep/semgrep#11069

## Context
CI lint job has been failing since setuptools removed `pkg_resources` in v82+. The semgrep opentelemetry dependency imported it, causing the crash. Fixed in semgrep v1.137.0.