### PR TITLE
chore: Switch pre-commit to prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ jobs:
           python-version: '3.11'
       - name: Setup uv
         uses: ./.github/actions/setup-uv
-      - name: Cache pre-commit hooks
-        id: cache-pre-commit
+      - name: Cache prek hooks
+        id: cache-prek
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ~/.cache/prek
+          key: ${{ runner.os }}-prek-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pre-commit-
+            ${{ runner.os }}-prek-
       - name: Install linting tools
         run: |
           sudo apt-get update
@@ -38,10 +38,10 @@ jobs:
           sudo chmod +x /usr/local/bin/hadolint
       - name: Create uv venv
         run: ~/.local/bin/uv venv
-      - name: Install pre-commit
-        run: ~/.local/bin/uv pip install pre-commit
-      - name: Run pre-commit checks
-        run: ~/.local/bin/uv run pre-commit run --all-files
+      - name: Install prek
+        run: ~/.local/bin/uv pip install prek
+      - name: Run prek checks
+        run: ~/.local/bin/uv run prek run --all-files
 
   translations:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Changes that violate the philosophy of this project will be rejected. Changes th
 
 ## Code Style
 
-We use `pre-commit` to enforce code style. Please make sure to install the pre-commit hooks with `pre-commit install` before you start working.
+We use [`prek`](https://github.com/j178/prek) (a drop-in compatible reimplementation of `pre-commit`) to enforce code style. Install it (e.g. `uv tool install prek`, `brew install prek`, or `uv pip install prek` inside the project venv) and register the git hook with `prek install` before you start working. The hook config still lives in `.pre-commit-config.yaml`.
 
 The primary tools we use are:
 *   `actionlint` for GitHub Actions workflows.
@@ -86,7 +86,7 @@ The primary tools we use are:
 *   `shellcheck` for shell scripts.
 *   `yamllint` for YAML files.
 
-Running `pre-commit run` before committing will ensure your code meets our style guidelines.
+Running `prek run` before committing will ensure your code meets our style guidelines.
 
 ## Commit Messages
 


### PR DESCRIPTION
## Summary

- Swap `pre-commit` (Python) for [`prek`](https://github.com/j178/prek), a drop-in compatible Rust reimplementation, in CI and contributor docs.
- `.pre-commit-config.yaml` is unchanged — prek reads the same file and runs the same hooks.
- CI now installs `prek` via `uv pip install prek` and caches `~/.cache/prek` instead of `~/.cache/pre-commit`.

## Why

Faster cold-start (no Python bootstrap for the hook runner), same config, same hooks. Running `prek run --all-files` locally on this branch produced identical pass/skip results to pre-commit.

## Test plan

- [ ] Lint_and_format CI job passes on this PR.
- [ ] Verify \`~/.cache/prek\` cache hit on a re-run.
- [ ] Local contributors update their git hook: \`rm .git/hooks/pre-commit && prek install\`.