### PR TITLE
Prevent possible XSS risk with Birds of the World URLs

### DIFF
--- a/src/birdnetpi/web/static/js/species_checklist.js
+++ b/src/birdnetpi/web/static/js/species_checklist.js
@@ -279,7 +279,18 @@ function createSpeciesRow(species) {
     const commonNameDiv = tempDiv.querySelector(".common-name");
     if (commonNameDiv) {
       const commonNameText = commonNameDiv.textContent;
-      commonNameDiv.innerHTML = `<a href="${species.bow_url}" target="_blank" rel="noopener noreferrer" class="bow-link" aria-label="Birds of the World: ${species.scientific_name}">${commonNameText}</a>`;
+      const bowLink = document.createElement("a");
+      bowLink.href = species.bow_url;
+      bowLink.target = "_blank";
+      bowLink.rel = "noopener noreferrer";
+      bowLink.className = "bow-link";
+      bowLink.setAttribute(
+        "aria-label",
+        `Birds of the World: ${species.scientific_name}`,
+      );
+      bowLink.textContent = commonNameText;
+      commonNameDiv.textContent = "";
+      commonNameDiv.appendChild(bowLink);
     }
     nameCell.innerHTML = tempDiv.innerHTML;
   } else {


### PR DESCRIPTION
Potential fix for [https://github.com/mverteuil/BirdNET-Pi/security/code-scanning/5](https://github.com/mverteuil/BirdNET-Pi/security/code-scanning/5)

Use DOM APIs instead of building HTML strings for the anchor element.  
Best fix in this snippet:

- Keep `taxonomyHtml` rendering as-is for now (to avoid broader behavior changes).
- After parsing into `tempDiv`, replace the `commonNameDiv.innerHTML = ...` template string with explicit element creation:
  - Create `<a>` via `document.createElement("a")`
  - Set `href`, `target`, `rel`, `className`, and `aria-label` via properties/`setAttribute`
  - Set link text via `textContent = commonNameText`
  - Clear `commonNameDiv` and append the anchor node
- Keep final `nameCell.innerHTML = tempDiv.innerHTML;` unchanged to preserve existing output behavior.

This removes the specific “DOM text reinterpreted as HTML” flow on line 282 and avoids reparsing `commonNameText` as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
